### PR TITLE
Remove hypemanInstallPath dependency

### DIFF
--- a/lib/hypeman.lua
+++ b/lib/hypeman.lua
@@ -5,11 +5,6 @@
 -- The DO SCRIPT assert(loadfile())() is preferred because then HypeMan can be updated and modified
 -- and applied to all .miz files without having to modify each individually.
 
--- HypeMan requires JSON.lua from here http://regex.info/blog/lua/json in C:\HypeMan
--- TODO - can this be loaded with loadfile()?
-local JSONLibPath = hypemanInstallPath.."/JSON.lua"
-JSON = (loadfile(JSONLibPath))() -- one-time load of the routines
-
 HypeMan = {}
 -- Configuration Options
 local HypeManAnnounceTakeoffs = true
@@ -45,7 +40,7 @@ HypeManHitTable = {}
 
 HypeMan.sendBotTable = function(tbl)
     -- env.info(msg)  -- for debugging
-    local tbl_json_txt = JSON:encode(tbl)
+    local tbl_json_txt = net.lua2json(tbl)
     socket.try(HypeMan.UDPSendSocket:sendto(tbl_json_txt, '127.0.0.1', 10081))
     -- msg = nil  -- setting to nil in attempt to debug why message queue seems to grow
 end

--- a/settings/Mariana/hypeman-settings-mariana.lua
+++ b/settings/Mariana/hypeman-settings-mariana.lua
@@ -3,5 +3,4 @@
 --- Created by oufy.
 --- DateTime: 18/09/2021 15:45
 ---
-hypemanInstallPath = "C:/hypeman-jtff-airboss/src"
 missionName = "Template_Mariane"

--- a/settings/NTTR/hypeman-settings-NTTR.lua
+++ b/settings/NTTR/hypeman-settings-NTTR.lua
@@ -3,5 +3,4 @@
 --- Created by oufy.
 --- DateTime: 18/09/2021 15:45
 ---
-hypemanInstallPath = "C:/hypeman-jtff-airboss/src"
 missionName = "Template_NTTR"

--- a/settings/PersianGulf/hypeman-settings-persian.lua
+++ b/settings/PersianGulf/hypeman-settings-persian.lua
@@ -3,5 +3,4 @@
 --- Created by oufy.
 --- DateTime: 18/09/2021 15:45
 ---
-hypemanInstallPath = "C:/hypeman-jtff-airboss/src"
 missionName = "Template_PersianGulf"

--- a/settings/Syria/hypeman-settings-syria.lua
+++ b/settings/Syria/hypeman-settings-syria.lua
@@ -3,5 +3,4 @@
 --- Created by oufy.
 --- DateTime: 18/09/2021 15:45
 ---
-hypemanInstallPath = "C:/hypeman-jtff-airboss/src"
 missionName = "Template_Syria"

--- a/templates/settings/settings-hypeman.lua
+++ b/templates/settings/settings-hypeman.lua
@@ -3,5 +3,4 @@
 --- Created by oufy.
 --- DateTime: 18/09/2021 15:45
 ---
-hypemanInstallPath = "C:/hypeman-jtff-airboss/src"
 missionName = "Template_Mariane"


### PR DESCRIPTION
hypemanInstallPath has necessary only for JSON.lua. Use the net.lua2json methode that used the JSON.lua internal script from DCS.